### PR TITLE
t1: Change home button to return KEY_HOMEPAGE instead of KEY_HOME

### DIFF
--- a/arch/arm/mach-omap2/board-t1-input.c
+++ b/arch/arm/mach-omap2/board-t1-input.c
@@ -100,7 +100,7 @@ static struct gpio_event_direct_entry t1_gpio_keypad_keys_map_low[] = {
 		.code	= KEY_VOLUMEDOWN,
 	},
 	[GPIO_HOME_KEY] = {
-		.code	= KEY_HOME,
+		.code	= KEY_HOMEPAGE,
 	},
 };
 


### PR DESCRIPTION
Android no longer recognizes the value KEY_HOME represents in the kernel as the home button
in userspace.

Change-Id: Ibd6164fcf3dba25d0b7c5c7d179885dfe87f966f